### PR TITLE
Embed a WebExtension, and get it to mirror the Profiler preferences.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
     "test": "jpm test",
     "start-mac-nightly": "jpm run --binary /Applications/FirefoxNightly.app",
     "test-mac-nightly": "jpm test --binary /Applications/FirefoxNightly.app"
-  }
+  },
+  "hasEmbeddedWebExtension": true
 }

--- a/webextension/background.js
+++ b/webextension/background.js
@@ -1,0 +1,12 @@
+"use strict";
+
+// The SDK add-on will tell us about any important preferences that we need
+// to migrate to WebExtension storage.
+let port = browser.runtime.connect({ name: "sync-legacy-preferences" });
+
+port.onMessage.addListener(msg => {
+  if (msg) {
+    browser.storage.local.set(msg);
+  }
+});
+

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "Gecko Profiler Add-on",
+  "version": "3.0.0",
+  "manifest_version": 2,
+  "permissions": ["storage"],
+  "background": {
+    "scripts": ["background.js"]
+  }
+}


### PR DESCRIPTION
Just putting a shovel into the ground to get this thing ported to a WebExtension.

Right now, it just does something simple - it mirrors the Preferences to the WebExtension local storage system, and keeps it up to date when the user changes it in the SDK Add-on.